### PR TITLE
Update activehdl_interface.py

### DIFF
--- a/vunit/activehdl_interface.py
+++ b/vunit/activehdl_interface.py
@@ -453,7 +453,7 @@ class VersionConsumer(object):
         self.major = None
         self.minor = None
 
-    _version_re = re.compile(r"(?P<major>\d+)\.(?P<minor>\d+)\.\d+\.\d+")
+    _version_re = re.compile(r"(?P<major>\d+)\.(?P<minor>\d+)[a-zA-Z]?\.\d+\.\d+")
 
     def __call__(self, line):
         match = self._version_re.search(line)


### PR DESCRIPTION
Fix for bug relating to issue: Active-HDL 10.5a not adding package generics #584
